### PR TITLE
Add README and env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,6 @@
+SMTP_HOST=smtp.example.com
+SMTP_USERNAME=example_user
+SMTP_PASSWORD=example_pass
+SMTP_PORT=587
+MAIL_FROM=from@example.com
+MAIL_TO=to@example.com

--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# Corpotech Website
+
+This repository contains the source code for a simple company website. The project is built using HTML, CSS and JavaScript with a small PHP script that uses [PHPMailer](https://github.com/PHPMailer/PHPMailer) to send contact form submissions via SMTP.
+
+## Setup
+
+1. **Install PHP and Composer** if they are not already available on your system.
+2. Install the project dependencies:
+
+   ```bash
+   composer install
+   ```
+3. Copy `.env.example` to `.env` and provide the SMTP credentials used by the contact form:
+
+   ```bash
+   cp .env.example .env
+   # then edit .env and fill in the values
+   ```
+
+## Running the site
+
+Serve the `public` directory with a web server. For local development you can use PHP's built‑in server:
+
+```bash
+php -S localhost:8000 -t public
+```
+
+Then open `http://localhost:8000` in your browser.
+
+## Project structure
+
+- `public/` – contains all static assets and the `send-email.php` script handling contact form requests.
+- `composer.json` – defines PHP dependencies (`phpmailer/phpmailer` and `vlucas/phpdotenv`).
+
+Feel free to customize the site content and styles under `public/`.


### PR DESCRIPTION
## Summary
- document how to set up and run the site
- provide `.env.example` with placeholders for SMTP values

## Testing
- `composer install` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68415daffca08329bd5e1c4363346aa2